### PR TITLE
Set library type to dynamic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,7 @@ let package = Package(
     ],
     products: [
         .library(name: "OSLog",
+                 type: .dynamic,
                  targets: ["OSLog"]),
     ],
     targets: [


### PR DESCRIPTION
Fixes issue when library is dependency of multiple libraries. See [developer.apple.com thread](https://developer.apple.com/forums/thread/128806).